### PR TITLE
Fix for IE8- Array indexOf()

### DIFF
--- a/instafetch.js
+++ b/instafetch.js
@@ -1,3 +1,49 @@
+
+/***
+
+##FIX for IE8(-) Array indexOf
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
+
+***/
+if (!Array.prototype.indexOf) {
+  Array.prototype.indexOf = function(searchElement, fromIndex) {
+
+    var k;
+
+    if (this == null) {
+      throw new TypeError('"this" is null or not defined');
+    }
+
+    var O = Object(this);
+
+    var len = O.length >>> 0;
+
+    if (len === 0) {
+      return -1;
+    }
+
+    var n = +fromIndex || 0;
+
+    if (Math.abs(n) === Infinity) {
+      n = 0;
+    }
+
+    if (n >= len) {
+      return -1;
+    }
+
+    k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+    while (k < len) {
+      if (k in O && O[k] === searchElement) {
+        return k;
+      }
+      k++;
+    }
+    return -1;
+  };
+}
+
 var MAX_RETURN = 33;
 
 function Instafetch(clientId) {


### PR DESCRIPTION
The application crashes in Internet Explorer 8 and previous versions, because it requires the use of Array.indeOf().

I just add a polyfill to **enable** Array.indeOx() support in IE8(-) browsers.

To a better understand go to [this link in MND](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf).
